### PR TITLE
Add enum value for WorkloadMetadataConfig

### DIFF
--- a/google/cloud/container_v1beta1/types/cluster_service.py
+++ b/google/cloud/container_v1beta1/types/cluster_service.py
@@ -3200,6 +3200,7 @@ class WorkloadMetadataConfig(proto.Message):
         UNSPECIFIED = 0
         SECURE = 1
         EXPOSE = 2
+        GKE_METADATA_SERVER = 3
 
     node_metadata = proto.Field(proto.ENUM, number=1, enum=NodeMetadata,)
 


### PR DESCRIPTION
The enum implemented in `cluster_service.py` does not implement the full
set of enum values for the WorkloadMetadataConfig options available in
the [v1beta1 NodeMetadata API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/NodeConfig#nodemetadata)
Adding additional enum lookup value.

Fixes #47 
