### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/yoshi-python is the default owner for changes in this repo
-*               @googleapis/yoshi-python
+*               @googleapis/yoshi-python @googleapis/cicd
 
 # The python-samples-reviewers team is the default owner for samples changes
 /samples/  @googleapis/python-samples-owners


### PR DESCRIPTION
fix #58 
update codeowners to include dpe cicd team

