### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.21.2, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "proto-plus >= 1.4.0",
-    "packaging >= 14.3"
-    "libcst >= 0.2.5",
+    "packaging >= 14.3" "libcst >= 0.2.5",
 ]
 extras = {}
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.21.2, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "proto-plus >= 1.4.0",
+    "packaging >= 14.3"
     "libcst >= 0.2.5",
 ]
 extras = {}

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ dependencies = [
     "google-api-core[grpc] >= 1.21.2, < 2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "proto-plus >= 1.4.0",
-    "packaging >= 14.3" "libcst >= 0.2.5",
+    "packaging >= 14.3",
+    "libcst >= 0.2.5",
 ]
 extras = {}
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,4 +8,5 @@
 google-api-core==1.26.3
 grpc-google-iam-v1==0.12.3
 proto-plus==1.4.0
-libcst==0.2.5packaging==14.3
+libcst==0.2.5
+packaging==14.3

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,4 +8,4 @@
 google-api-core==1.26.3
 grpc-google-iam-v1==0.12.3
 proto-plus==1.4.0
-libcst==0.2.5
+libcst==0.2.5packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3