### PR TITLE
chore: change order of default owners in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/yoshi-python is the default owner for changes in this repo
-*               @googleapis/yoshi-python @googleapis/anthos-dpe
+# @googleapis/anthos-dpe and @googleapis/yoshi-python are the default owner for changes in this repo
+*              @googleapis/anthos-dpe @googleapis/yoshi-python 
 
 # The python-samples-reviewers team is the default owner for samples changes
 /samples/  @googleapis/python-samples-owners


### PR DESCRIPTION
Only googleapis/yoshi-python is showing as a codeowner for this repo. I'm expecting anthos-dpe to also be a code owner. I'd like to try switching the order of these 2 teams in the code owners file to see if there is any difference.