### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "container",
     "name_pretty": "Kubernetes Engine",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/",
-    "client_documentation": "https://googleapis.dev/python/container/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/container/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559746",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.