### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "container",
     "name_pretty": "Kubernetes Engine",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/",
-    "client_documentation": "https://googleapis.dev/python/container/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/container/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559746",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Kubernetes technology.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-container.svg
    :target: https://pypi.org/project/google-cloud-container/
 .. _Google Kubernetes Engine API: https://cloud.google.com/kubernetes-engine
-.. _Client Library Documentation: https://googleapis.dev/python/container/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/container/latest
 .. _Product Documentation:  https://cloud.google.com/kubernetes-engine
 
 Quick Start
@@ -87,4 +87,4 @@ Next Steps
 -  Read the `Product documentation`_ to learn more about the product and see
    How-to Guides.
 
-.. _Client API Documentation: https://googleapis.dev/python/container/latest
+.. _Client API Documentation: https://cloud.google.com/python/docs/reference/container/latest


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.