### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,10 +17,10 @@ The 2.0.0 release requires Python 3.6+.
 
 Methods expect request objects. We provide a script that will convert most common use cases.
 
-* Install the library
+* Install the library with the `libcst` extra.
 
 ```py
-python3 -m pip install google-cloud-container
+python3 -m pip install google-cloud-container[libcst]
 ```
 
 * The script `fixup_container_v1_keywords.py` and `fixup_container_v1beta1_keywords.py`

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,8 @@ dependencies = [
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "proto-plus >= 1.15.0",
-    "libcst >= 0.2.5",
 ]
-extras = {}
+extras = {"libcst": "libcst >= 0.2.5"}
 
 
 # Setup boilerplate below this line.


### PR DESCRIPTION
`libcst` is only needed to run the fixup script (used when migrating from the last major version). 
